### PR TITLE
fix: Community API DTO 타입 불일치 및 FETCH JOIN 오류 해결

### DIFF
--- a/src/main/java/com/gaebang/backend/domain/community/dto/response/BoardListProjectionDto.java
+++ b/src/main/java/com/gaebang/backend/domain/community/dto/response/BoardListProjectionDto.java
@@ -1,0 +1,18 @@
+package com.gaebang.backend.domain.community.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record BoardListProjectionDto(
+        Long boardId,              // 게시글 ID
+        String title,              // 제목
+        Long commentCount,         // 댓글 수 (COUNT 결과는 Long)
+        String writer,             // 작성자(글쓴이)
+        String imageUrl,           // 이미지 URL
+        LocalDateTime createdDate, // 작성일 (DB 타입)
+        Long viewCount,            // 조회수
+        Long likeCount             // 추천수 (COUNT 결과는 Long)
+) {
+}

--- a/src/main/java/com/gaebang/backend/domain/community/dto/response/BoardListResponseDto.java
+++ b/src/main/java/com/gaebang/backend/domain/community/dto/response/BoardListResponseDto.java
@@ -13,12 +13,12 @@ import java.time.format.DateTimeFormatter;
 public record BoardListResponseDto(
         Long boardId,              // 게시글 ID
         String title,              // 제목
-        int commentCount,          // 댓글 수
+        Long commentCount,          // 댓글 수
         String writer,             // 작성자(글쓴이)
         String imageUrl,           // 이미지 URL
         String createdDate,        // 작성일
-        int viewCount,             // 조회수
-        int likeCount              // 추천수
+        Long viewCount,             // 조회수
+        Long likeCount              // 추천수
 ) {
     /*public static BoardListResponseDto fromEntity(Board board) {
         return new BoardListResponseDto(

--- a/src/main/java/com/gaebang/backend/domain/community/repository/BoardRepository.java
+++ b/src/main/java/com/gaebang/backend/domain/community/repository/BoardRepository.java
@@ -1,6 +1,7 @@
 package com.gaebang.backend.domain.community.repository;
 
 import com.gaebang.backend.domain.community.dto.response.BoardListResponseDto;
+import com.gaebang.backend.domain.community.dto.response.BoardListProjectionDto;
 import com.gaebang.backend.domain.community.entity.Board;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,7 +13,7 @@ import java.util.Optional;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
-    @Query(value = "SELECT new com.gaebang.backend.domain.community.dto.response.BoardListResponseDto(" +
+    @Query(value = "SELECT new com.gaebang.backend.domain.community.dto.response.BoardListProjectionDto(" +
             "b.id, " +
             "b.title," +
             "COUNT(distinct c)," +
@@ -21,8 +22,10 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
             "(SELECT MIN(img2.id) FROM Image img2 WHERE img2.board = b))," +
             "b.createdAt," +
             "b.viewCount, " +
-            "COUNT(distinct bl)) FROM Board b LEFT JOIN b.comments c LEFT JOIN b.boardLikes bl " +
-            "where b.deleteYn = 'N' AND (b.title LIKE CONCAT('%', :condition, '%') " +
+            "COUNT(distinct bl)) FROM Board b " +
+            "LEFT JOIN b.comments c " +
+            "LEFT JOIN b.boardLikes bl " +
+            "WHERE b.deleteYn = 'N' AND (b.title LIKE CONCAT('%', :condition, '%') " +
             "OR b.member.memberBase.nickname LIKE CONCAT('%', :condition, '%') " +
             "OR b.content LIKE CONCAT('%', :condition, '%')) " +
             "GROUP BY b",
@@ -32,9 +35,9 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
                     "AND (b.title LIKE CONCAT('%', :condition, '%') " +
                     "OR b.member.memberBase.nickname LIKE CONCAT('%', :condition, '%') " +
                     "OR b.content LIKE CONCAT('%', :condition, '%'))")
-    Page<BoardListResponseDto> findByCondition(@Param("condition") String condition, Pageable pageable);
+    Page<BoardListProjectionDto> findByCondition(@Param("condition") String condition, Pageable pageable);
 
-    @Query(value = "SELECT new com.gaebang.backend.domain.community.dto.response.BoardListResponseDto(" +
+    @Query(value = "SELECT new com.gaebang.backend.domain.community.dto.response.BoardListProjectionDto(" +
             "b.id, " +
             "b.title," +
             "COUNT(distinct c)," +
@@ -43,14 +46,14 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
             "(SELECT MIN(img2.id) FROM Image img2 WHERE img2.board = b))," +
             "b.createdAt," +
             "b.viewCount, " +
-            "COUNT(distinct bl)) FROM Board b LEFT JOIN b.comments c LEFT JOIN b.boardLikes bl " +
+            "COUNT(distinct bl)) FROM Board b " +
+            "LEFT JOIN b.comments c " +
+            "LEFT JOIN b.boardLikes bl " +
             "WHERE b.deleteYn = 'N' AND b.member.memberBase.nickname like CONCAT('%', :writer, '%') " +
             "GROUP BY b",
             countQuery = "SELECT COUNT(DISTINCT b) FROM Board b " +
-                    "LEFT JOIN b.comments c WHERE b.deleteYn = 'N' AND (b.title LIKE CONCAT('%', :condition, '%') " +
-                    "OR b.member.memberBase.nickname LIKE CONCAT('%', :condition, '%') " +
-                    "OR b.content LIKE CONCAT('%', :condition, '%'))")
-    Page<BoardListResponseDto> findByWriter(@Param("writer") String writer, Pageable pageable);
+                    "WHERE b.deleteYn = 'N' AND b.member.memberBase.nickname LIKE CONCAT('%', :writer, '%')")
+    Page<BoardListProjectionDto> findByWriter(@Param("writer") String writer, Pageable pageable);
 
     // 통합으로 정책 변경으로 일단 주석처리
     /*@Query(value = "SELECT new com.gaebang.backend.domain.community.dto.response.BoardResponseDto(" +
@@ -67,7 +70,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
                     "LEFT JOIN b.comments c WHERE b.title LIKE %:content%")
     Page<BoardResponseDto> findByContent(@Param("content") String content, Pageable pageable);*/
 
-    @Query(value = "SELECT new com.gaebang.backend.domain.community.dto.response.BoardListResponseDto(" +
+    @Query(value = "SELECT new com.gaebang.backend.domain.community.dto.response.BoardListProjectionDto(" +
             "b.id, " +
             "b.title," +
             "COUNT(distinct c)," +
@@ -76,12 +79,14 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
             "(SELECT MIN(img2.id) FROM Image img2 WHERE img2.board = b))," +
             "b.createdAt," +
             "b.viewCount, " +
-            "COUNT(distinct bl)) FROM Board b LEFT JOIN b.comments c LEFT JOIN b.boardLikes bl " +
+            "COUNT(distinct bl)) FROM Board b " +
+            "LEFT JOIN b.comments c " +
+            "LEFT JOIN b.boardLikes bl " +
             "WHERE b.deleteYn = 'N' " +
             "GROUP BY b",
             countQuery = "SELECT COUNT(DISTINCT b) FROM Board b " +
-                    "LEFT JOIN b.comments c WHERE b.deleteYn = 'N'")
-    Page<BoardListResponseDto> findAllBoardDtos(Pageable pageable);
+                    "WHERE b.deleteYn = 'N'")
+    Page<BoardListProjectionDto> findAllBoardDtos(Pageable pageable);
 
     @Query("SELECT b FROM Board b WHERE b.id = :id AND b.member.id = :memberId AND b.deleteYn = 'N'")
     Optional<Board> findByIdAndMemberId(@Param("id") Long id, @Param("memberId") Long memberId);

--- a/src/main/java/com/gaebang/backend/domain/community/service/BoardService.java
+++ b/src/main/java/com/gaebang/backend/domain/community/service/BoardService.java
@@ -2,6 +2,7 @@ package com.gaebang.backend.domain.community.service;
 
 import com.gaebang.backend.domain.community.dto.reqeust.BoardCreateAndEditRequestDto;
 import com.gaebang.backend.domain.community.dto.response.BoardListResponseDto;
+import com.gaebang.backend.domain.community.dto.response.BoardListProjectionDto;
 import com.gaebang.backend.domain.community.dto.response.BoardDetailResponseDto;
 import com.gaebang.backend.domain.community.dto.response.CommentResponseDto;
 import com.gaebang.backend.domain.community.entity.Board;
@@ -35,15 +36,15 @@ public class BoardService {
     private final CommentService commentService;
     private final TimeUtil timeUtil;
 
-    private Page<BoardListResponseDto> transformBoardDtos(Page<BoardListResponseDto> boardDtos) {
-        return boardDtos.map(dto ->
+    private Page<BoardListResponseDto> transformBoardDtos(Page<BoardListProjectionDto> projectionDtos) {
+        return projectionDtos.map(dto ->
                 BoardListResponseDto.builder()
                         .boardId(dto.boardId())
                         .title(dto.title())
                         .commentCount(dto.commentCount())
                         .writer(dto.writer())
                         .imageUrl(dto.imageUrl())
-                        .createdDate(timeUtil.getDisplayTimeFromString(dto.createdDate()))
+                        .createdDate(timeUtil.getDisplayTime(dto.createdDate()))
                         .viewCount(dto.viewCount())
                         .likeCount(dto.likeCount())
                         .build()
@@ -52,13 +53,13 @@ public class BoardService {
 
     // 검색 조건 있을 시 사용
     public Page<BoardListResponseDto> getBoardByCondition(String condition, Pageable pageable) {
-        Page<BoardListResponseDto> getDtos = boardRepository.findByCondition(condition, pageable);
+        Page<BoardListProjectionDto> getDtos = boardRepository.findByCondition(condition, pageable);
         return transformBoardDtos(getDtos);
     }
 
     // 마이페이지 조회 시 사용
     public Page<BoardListResponseDto> getBoardByWriter(String writer, Pageable pageable) {
-        Page<BoardListResponseDto> getDtos = boardRepository.findByWriter(writer, pageable);
+        Page<BoardListProjectionDto> getDtos = boardRepository.findByWriter(writer, pageable);
         return transformBoardDtos(getDtos);
     }
 
@@ -71,7 +72,7 @@ public class BoardService {
 
     // 검색 조건 없이 조회
     public Page<BoardListResponseDto> getBoard(Pageable pageable) {
-        Page<BoardListResponseDto> getDtos = boardRepository.findAllBoardDtos(pageable);
+        Page<BoardListProjectionDto> getDtos = boardRepository.findAllBoardDtos(pageable);
         return transformBoardDtos(getDtos);
     }
 


### PR DESCRIPTION
## 📋 변경사항 요약
- BoardListProjectionDto 생성으로 Repository-Service 간 타입 안정성 확보
- JPQL 프로젝션에서 부적절한 FETCH JOIN 제거
- COUNT 함수 결과 타입을 Long으로 통일하여 생성자 오류 해결
- LocalDateTime → "59분 전" 변환 기능 유지

## 🎯 변경 이유
1. 타입 불일치 오류
문제: Repository JPQL에서 LocalDateTime을 반환하는데 기존 BoardListResponseDto는 String createdDate로 정의

2. FETCH JOIN 오용
문제: DTO 프로젝션(SELECT new DTO(...))에서 FETCH JOIN 사용

3. COUNT 함수 타입 문제
문제: COUNT() 함수는 Long 반환하는데 DTO에서 int로 정의

4. "59분 전" 기능과 성능 양립 문제
문제: 사용자 친화적 시간 표시 + JPQL 프로젝션 성능 최적화를 동시에 달성해야 함

해결: 중간 DTO 패턴으로 DB 타입(LocalDateTime)과 API 타입(String) 분리

## 🔧 변경 내용
<!-- 구체적으로 어떤 부분을 수정했는지 체크리스트로 작성해주세요 -->
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가
- [ ] 기타: 

## 🧪 테스트
<!-- 어떻게 테스트했는지 설명해주세요 -->
- [ ] 로컬에서 테스트 완료
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 확인
- [ ] 수동 테스트 완료

## ✅ 체크리스트
- [ ] 코드 리뷰 준비 완료
- [ ] 커밋 메시지가 명확함
- [ ] 문서 업데이트 (필요한 경우)
- [ ] 테스트 코드 작성/수정
- [ ] 충돌 해결 완료