### PR TITLE
feat: 면접 API 응답에 총 질문수와 현재 인덱스 추가

### DIFF
--- a/src/main/java/com/gaebang/backend/domain/interview/dto/response/NextTurnResponseDto.java
+++ b/src/main/java/com/gaebang/backend/domain/interview/dto/response/NextTurnResponseDto.java
@@ -9,6 +9,7 @@ public record NextTurnResponseDto(
         List<String> answerGuides,      // 🆕 답변 가이드
         String coachingTips,            // 이전 답변 피드백
         Map<String, Integer> scoreDelta,
+        int currentIndex,               // 🆕 현재 질문 인덱스
         boolean done,
         TtsPayloadDto tts
 ) {

--- a/src/main/java/com/gaebang/backend/domain/interview/dto/response/StartSessionResponseDto.java
+++ b/src/main/java/com/gaebang/backend/domain/interview/dto/response/StartSessionResponseDto.java
@@ -6,6 +6,7 @@ public record StartSessionResponseDto(
         UUID sessionId,
         String greeting,
         String firstQuestion,
+        int totalQuestions,
         TtsPayloadDto tts
 ) {
 }

--- a/src/main/java/com/gaebang/backend/domain/interview/service/InterviewService.java
+++ b/src/main/java/com/gaebang/backend/domain/interview/service/InterviewService.java
@@ -133,6 +133,7 @@ public class InterviewService {
         InterviewPlanDto plan = planParser.parse(planJson);
         String firstQuestion = plan.questions().get(0).text();
         String greeting = ai.generateGreeting(displayName);
+        int totalQuestions = plan.questions().size();
 
         // withAudio면 첫 질문(필요시 greeting 포함) 음성 생성
         TtsPayloadDto tts = null;
@@ -145,7 +146,7 @@ public class InterviewService {
             }
         }
 
-        return new StartSessionResponseDto(sessionId, greeting, firstQuestion, tts);
+        return new StartSessionResponseDto(sessionId, greeting, firstQuestion, totalQuestions, tts);
     }
 
     @Transactional
@@ -318,7 +319,7 @@ public class InterviewService {
         log.info("[PERF] nextTurn 메서드 완료 - 전체 실행 시간: {} ms (AI: {} ms, 병렬처리)", 
                 methodMs, elapsedMs);
                 
-        return new NextTurnResponseDto(nextQuestion, questionIntent, answerGuides, coachingTips, scoreResult, done, tts);
+        return new NextTurnResponseDto(nextQuestion, questionIntent, answerGuides, coachingTips, scoreResult, nextIndex, done, tts);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 📋 변경사항 요약
- /session API에 totalQuestions 필드 추가
- /turn API에 currentIndex 필드 추가
- 프론트엔드에서 진행상황 추적 가능하도록 개선

## 🔧 변경 내용
<!-- 구체적으로 어떤 부분을 수정했는지 체크리스트로 작성해주세요 -->
- [x] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [x] 문서 업데이트
- [ ] 테스트 추가
- [ ] 기타: 

## 🧪 테스트
<!-- 어떻게 테스트했는지 설명해주세요 -->
- [x] 로컬에서 테스트 완료
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 확인
- [x] 수동 테스트 완료

## ✅ 체크리스트
- [x] 코드 리뷰 준비 완료
- [x] 커밋 메시지가 명확함
- [ ] 문서 업데이트 (필요한 경우)
- [ ] 테스트 코드 작성/수정
- [ ] 충돌 해결 완료