### PR TITLE
fix: 문서 파싱 시스템 10개 필드 지원 및 토큰 한도 최적화

### DIFF
--- a/src/main/java/com/gaebang/backend/domain/interview/service/DocumentContentExtractor.java
+++ b/src/main/java/com/gaebang/backend/domain/interview/service/DocumentContentExtractor.java
@@ -81,6 +81,19 @@ public class DocumentContentExtractor {
         List<Map<String, String>> careers = extractCareers(sections);
         structuredInfo.put("careers", careers);
         
+        // 나머지 7개 항목 기본값으로 추가
+        structuredInfo.put("education", List.of());
+        structuredInfo.put("certifications", List.of());
+        structuredInfo.put("achievements", List.of());
+        structuredInfo.put("portfolio", Map.of(
+            "github", "정보 없음",
+            "blog", "정보 없음", 
+            "website", "정보 없음"
+        ));
+        structuredInfo.put("languages", List.of());
+        structuredInfo.put("specialties", List.of());
+        structuredInfo.put("preferences", List.of());
+        
         return structuredInfo;
     }
     


### PR DESCRIPTION
## 📋 변경사항 요약
- Gemini extractDocumentInfo maxOutputTokens 3000→7000 증가
- finishReason, thoughtsTokenCount 디버깅 로깅 추가
- 정규식 폴백을 3개→10개 항목으로 확장
- JSON 파싱 실패 시 10개 항목 빈 구조 반환

## 🔧 변경 내용
<!-- 구체적으로 어떤 부분을 수정했는지 체크리스트로 작성해주세요 -->
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트
- [ ] 테스트 추가
- [ ] 기타: 

## 🧪 테스트
<!-- 어떻게 테스트했는지 설명해주세요 -->
- [x] 로컬에서 테스트 완료
- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 확인
- [x] 수동 테스트 완료

## ✅ 체크리스트
- [x] 코드 리뷰 준비 완료
- [x] 커밋 메시지가 명확함
- [ ] 문서 업데이트 (필요한 경우)
- [ ] 테스트 코드 작성/수정
- [ ] 충돌 해결 완료